### PR TITLE
dictionary match

### DIFF
--- a/lib/zxcvbn/matching.ex
+++ b/lib/zxcvbn/matching.ex
@@ -100,8 +100,7 @@ defmodule Zxcvbn.Matching do
   def dictionary_match(password, ranked_dictionaries \\ @ranked_dictionaries) do
     password
     |> word_permutations
-    |> Enum.map(fn word -> dictionaries_matches(ranked_dictionaries, word, []) end)
-    |> List.flatten()
+    |> Enum.flat_map(&dictionaries_matches(ranked_dictionaries, &1, []))
   end
 
   defp word_permutations(word) do

--- a/lib/zxcvbn/matching.ex
+++ b/lib/zxcvbn/matching.ex
@@ -108,28 +108,31 @@ defmodule Zxcvbn.Matching do
 
     for i <- 0..len,
         j <- 1..(len - i),
-        do: %{
-          i: i,
-          j: i + j - 1,
-          token: String.slice(word, i, j),
-          matched_word: String.downcase(String.slice(word, i, j)),
-          reversed: false,
-          l33t: false,
-          rank: nil,
-          dictionary_name: nil,
-          pattern: nil
-        }
+        do: %{i: i, j: i + j - 1, token: String.slice(word, i, j)}
   end
 
   defp dictionaries_matches([], _, matches), do: matches
 
   defp dictionaries_matches([head | tail], permutation, matches) do
-    case head.words[permutation.matched_word] do
+    matched_word = String.downcase(permutation.token)
+
+    case head.words[matched_word] do
       nil ->
         dictionaries_matches(tail, permutation, matches)
 
       rank ->
-        match = %{permutation | rank: rank, dictionary_name: head.name, pattern: "dictionary"}
+        match = %{
+          i: permutation.i,
+          j: permutation.j,
+          token: permutation.token,
+          matched_word: matched_word,
+          reversed: false,
+          l33t: false,
+          rank: rank,
+          dictionary_name: head.name,
+          pattern: "dictionary"
+        }
+
         dictionaries_matches(tail, permutation, matches ++ [match])
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+ExUnit.configure(exclude: :pending, trace: true)

--- a/test/zxcvbn/matching_test.exs
+++ b/test/zxcvbn/matching_test.exs
@@ -50,7 +50,7 @@ defmodule Zxcvbn.MatchingTest do
 
       assert match == expected
 
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
       expected = %{expected | i: 6, j: 10, rank: 3, token: "board", matched_word: "board"}
       assert match == expected
     end
@@ -74,7 +74,7 @@ defmodule Zxcvbn.MatchingTest do
 
       assert match == expected
 
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
       expected = %{expected | i: 2, j: 5, rank: 5, token: "cdef", matched_word: "cdef"}
       assert match == expected
     end
@@ -98,7 +98,7 @@ defmodule Zxcvbn.MatchingTest do
 
       assert match == expected
 
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
 
       expected = %{
         expected
@@ -118,7 +118,7 @@ defmodule Zxcvbn.MatchingTest do
       word = "asdf1234&*"
 
       matches = Matching.dictionary_match("q" <> word, dictionaries())
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
 
       expected = %{
         dict_match()
@@ -133,19 +133,19 @@ defmodule Zxcvbn.MatchingTest do
       assert match == expected
 
       matches = Matching.dictionary_match("%" <> word, dictionaries())
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
       assert match == expected
 
       matches = Matching.dictionary_match("q" <> word <> "%%", dictionaries())
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
       assert match == expected
 
       matches = Matching.dictionary_match("%" <> word <> "pp", dictionaries())
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
       assert match == expected
 
       matches = Matching.dictionary_match(word <> "%%", dictionaries())
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
 
       expected = %{
         dict_match()
@@ -160,7 +160,7 @@ defmodule Zxcvbn.MatchingTest do
       assert match == expected
 
       matches = Matching.dictionary_match(word <> "qq", dictionaries())
-      {match, matches} = List.pop_at(matches, 0)
+      {match, _} = List.pop_at(matches, 0)
       assert match == expected
     end
 

--- a/test/zxcvbn/matching_test.exs
+++ b/test/zxcvbn/matching_test.exs
@@ -1,3 +1,206 @@
 defmodule Zxcvbn.MatchingTest do
   use ExUnit.Case
+
+  alias Zxcvbn.Matching
+
+  describe "dictionary_match/2" do
+    # @tag :pending
+    test "empty passwords has no matches" do
+      dicts = [%{name: "d1", words: %{"motherboard" => 1}}]
+
+      matches = Matching.dictionary_match("", dicts)
+      assert Enum.empty?(matches)
+    end
+
+    # @tag :pending
+    test "empty dictionary has no matches" do
+      matches = Matching.dictionary_match("password", [])
+      assert Enum.empty?(matches)
+    end
+
+    # @tag :pending
+    test "matches words that contain other words" do
+      matches = Matching.dictionary_match("motherboard", dictionaries())
+      assert Enum.count(matches) == 3
+
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        dict_match()
+        | i: 0,
+          j: 5,
+          rank: 2,
+          token: "mother",
+          matched_word: "mother",
+          dictionary_name: "d1"
+      }
+
+      assert match == expected
+
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        expected
+        | i: 0,
+          j: 10,
+          rank: 1,
+          token: "motherboard",
+          matched_word: "motherboard"
+      }
+
+      assert match == expected
+
+      {match, matches} = List.pop_at(matches, 0)
+      expected = %{expected | i: 6, j: 10, rank: 3, token: "board", matched_word: "board"}
+      assert match == expected
+    end
+
+    # @tag :pending
+    test "matches multiple words when they overlap" do
+      matches = Matching.dictionary_match("abcdef", dictionaries())
+      assert Enum.count(matches) == 2
+
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        dict_match()
+        | i: 0,
+          j: 3,
+          rank: 4,
+          token: "abcd",
+          matched_word: "abcd",
+          dictionary_name: "d1"
+      }
+
+      assert match == expected
+
+      {match, matches} = List.pop_at(matches, 0)
+      expected = %{expected | i: 2, j: 5, rank: 5, token: "cdef", matched_word: "cdef"}
+      assert match == expected
+    end
+
+    # @tag :pending
+    test "ignores uppercasing" do
+      matches = Matching.dictionary_match("BoaRdZ", dictionaries())
+      assert Enum.count(matches) == 2
+
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        dict_match()
+        | i: 0,
+          j: 4,
+          rank: 3,
+          token: "BoaRd",
+          matched_word: "board",
+          dictionary_name: "d1"
+      }
+
+      assert match == expected
+
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        expected
+        | i: 5,
+          j: 5,
+          rank: 1,
+          token: "Z",
+          matched_word: "z",
+          dictionary_name: "d2"
+      }
+
+      assert match == expected
+    end
+
+    # @tag :pending
+    test "identifies words surrounded by non-words" do
+      word = "asdf1234&*"
+
+      matches = Matching.dictionary_match("q" <> word, dictionaries())
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        dict_match()
+        | i: 1,
+          j: 10,
+          rank: 5,
+          token: "asdf1234&*",
+          matched_word: "asdf1234&*",
+          dictionary_name: "d2"
+      }
+
+      assert match == expected
+
+      matches = Matching.dictionary_match("%" <> word, dictionaries())
+      {match, matches} = List.pop_at(matches, 0)
+      assert match == expected
+
+      matches = Matching.dictionary_match("q" <> word <> "%%", dictionaries())
+      {match, matches} = List.pop_at(matches, 0)
+      assert match == expected
+
+      matches = Matching.dictionary_match("%" <> word <> "pp", dictionaries())
+      {match, matches} = List.pop_at(matches, 0)
+      assert match == expected
+
+      matches = Matching.dictionary_match(word <> "%%", dictionaries())
+      {match, matches} = List.pop_at(matches, 0)
+
+      expected = %{
+        dict_match()
+        | i: 0,
+          j: 9,
+          rank: 5,
+          token: "asdf1234&*",
+          matched_word: "asdf1234&*",
+          dictionary_name: "d2"
+      }
+
+      assert match == expected
+
+      matches = Matching.dictionary_match(word <> "qq", dictionaries())
+      {match, matches} = List.pop_at(matches, 0)
+      assert match == expected
+    end
+
+    defp dictionaries() do
+      [
+        %{
+          name: "d1",
+          words: %{
+            "motherboard" => 1,
+            "mother" => 2,
+            "board" => 3,
+            "abcd" => 4,
+            "cdef" => 5
+          }
+        },
+        %{
+          name: "d2",
+          words: %{
+            "z" => 1,
+            "8" => 2,
+            "99" => 3,
+            "$" => 4,
+            "asdf1234&*" => 5
+          }
+        }
+      ]
+    end
+
+    defp dict_match() do
+      %{
+        pattern: "dictionary",
+        i: 0,
+        j: 0,
+        token: "",
+        matched_word: "",
+        rank: 0,
+        dictionary_name: "",
+        reversed: false,
+        l33t: false
+      }
+    end
+  end
 end


### PR DESCRIPTION
* turns out dictionary match proved to be a better first matching candidate (repeat_match uses omni_match)
* in favour of tail recursion on dictionaries, opted for a slightly different dict map `%{name: "name", words: %{}}`
* added almost all test cases from original repo except for the ones that require the actual dictionaries (the parsing would require some updates..)
* sorting not implemented so far, don't see any test coverage unless this would be included in the last 2 tests involving actual dictionaries